### PR TITLE
Prevent duplicate entries in display

### DIFF
--- a/src/Controller/DisplayController.php
+++ b/src/Controller/DisplayController.php
@@ -77,6 +77,7 @@ class DisplayController extends ControllerBase {
     function card(it) {
       const d = new Date(it.last * 1000).toLocaleString([], {hour:'2-digit', minute:'2-digit'});
       const el = document.createElement('article');
+      el.id = `k-card-${it.uid}`;
       el.className = 'k-card';
 
       if (it.photo) {
@@ -102,6 +103,7 @@ class DisplayController extends ControllerBase {
 
     function render(items) {
       for (const it of items) {
+        document.getElementById(`k-card-${it.uid}`)?.remove();
         GRID.prepend(card(it));
         lastSeen = Math.max(lastSeen, it.last);
       }


### PR DESCRIPTION
The display was showing duplicate entries for users whose records were updated. This happened because the frontend JavaScript would prepend a new card for the updated user without removing the old one.

This change modifies the JavaScript to assign a unique ID to each user card (e.g., `k-card-123`). Before adding a new card, the code now checks if a card with that ID already exists and removes it. This ensures that updated entries replace old ones instead of creating duplicates.