### PR TITLE
Fix access display “time-warp” reload behavior

### DIFF
--- a/src/Controller/PresenceFeedController.php
+++ b/src/Controller/PresenceFeedController.php
@@ -18,7 +18,7 @@ class PresenceFeedController extends ControllerBase {
     $db = \Drupal::database();
     $q = $db->select('access_display_presence', 'p')
       ->fields('p', ['uid','user_uuid','realname','door','first_seen','last_seen','scan_count'])
-      ->orderBy('last_seen', 'ASC')
+      ->orderBy('last_seen', 'DESC')
       ->range(0, $limit);
 
     if ($after > 0) {


### PR DESCRIPTION
When the access display page first loads after being closed for a while, it steps through past records before settling on the latest. This happens because the feed is ordered in ascending time.

This change updates the query builder in `src/Controller/PresenceFeedController.php` to sort results by `last_seen` in descending order. This ensures the newest records are returned first, preventing the UI from “walking forward in time” on initial load, while keeping incremental polling working correctly.